### PR TITLE
Add VS Code style file explorer

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,7 +1,12 @@
 # Nicks NeoVim Setup
 
-## Started with 
+## Started with
 ```git clone https://github.com/nvim-lua/kickstart.nvim ~/.config/nvim```
 
 ## Install the Plugin Manager lazy.nvim:
 ```git clone https://github.com/folke/lazy.nvim.git ~/.local/share/nvim/site/pack/lazy/start/lazy.nvim```
+
+## File Explorer
+The configuration uses **nvim-tree.lua** for browsing files.
+Toggle it with `<leader>e` (space + e). Files are displayed with icons thanks to **nvim-web-devicons**.
+

--- a/init.lua
+++ b/init.lua
@@ -12,9 +12,26 @@ vim.opt.termguicolors = true
 vim.opt.mouse = "a"
 vim.opt.clipboard = "unnamedplus"
 
+-- Leader Key
+vim.g.mapleader = " "
+
 -- Plugin Manager Bootstrap
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 vim.opt.rtp:prepend(lazypath)
 
 -- Plugin Setup
-require("lazy").setup()
+require("lazy").setup({
+  {
+    "nvim-tree/nvim-tree.lua",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    config = function()
+      require("nvim-tree").setup()
+      vim.keymap.set(
+        "n",
+        "<leader>e",
+        "<cmd>NvimTreeToggle<CR>",
+        { silent = true, desc = "Toggle file explorer" }
+      )
+    end,
+  },
+})


### PR DESCRIPTION
## Summary
- configure `nvim-tree` and `nvim-web-devicons` via lazy.nvim
- map `<leader>e` to toggle the file explorer
- document the file explorer and keymap

## Testing
- `nvim` not installed in container; no tests run

------
https://chatgpt.com/codex/tasks/task_e_6877d813f7c8832cb1fd7786a4f1d192