### PR TITLE
Add search-and-replace GUI with nvim-spectre

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -14,3 +14,7 @@ Toggle it with `<leader>e` (space + e). Files are displayed with icons thanks to
 The setup includes **telescope.nvim** for quickly finding files.
 Launch it with `<leader>f` (space + f).
 
+## Search and Replace
+For project-wide search and replace, the config now includes **nvim-spectre**.
+Open its panel with `<leader>s` (space + s).
+

--- a/init.lua
+++ b/init.lua
@@ -47,4 +47,17 @@ require("lazy").setup({
       )
     end,
   },
+  {
+    "nvim-pack/nvim-spectre",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    config = function()
+      require("spectre").setup()
+      vim.keymap.set(
+        "n",
+        "<leader>s",
+        function() require("spectre").open() end,
+        { silent = true, desc = "Search and Replace" }
+      )
+    end,
+  },
 })


### PR DESCRIPTION
## Summary
- add `nvim-spectre` plugin for project-wide search and replace
- document how to open the search panel

## Testing
- `luac` and `lua` not available, unable to run syntax checks

------
https://chatgpt.com/codex/tasks/task_e_6877faa6796c832ca45f42d75dae9154