### PR TITLE
Add no-op mapping for Space

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,6 +15,9 @@ vim.opt.clipboard = "unnamedplus"
 -- Leader Key
 vim.g.mapleader = " "
 
+-- Make space do nothing in normal and visual modes
+vim.keymap.set({ "n", "v" }, "<Space>", "<Nop>", { silent = true })
+
 -- Plugin Manager Bootstrap
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 vim.opt.rtp:prepend(lazypath)


### PR DESCRIPTION
## Summary
- disable space in normal & visual modes to ensure `<Space>` only acts as the leader key

## Testing
- `nvim --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878062d2e58832caf5528a2308c5b0e