### PR TITLE
Add VS Code theme plugin

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -14,3 +14,6 @@ Toggle it with `<leader>e` (space + e). Files are displayed with icons thanks to
 The setup includes **telescope.nvim** for quickly finding files.
 Launch it with `<leader>f` (space + f).
 
+## VS Code Theme
+The colorscheme uses **Mofiqul/vscode.nvim** to mimic VS Code's look.
+

--- a/init.lua
+++ b/init.lua
@@ -50,4 +50,11 @@ require("lazy").setup({
       )
     end,
   },
+  {
+    "Mofiqul/vscode.nvim",
+    config = function()
+      require("vscode").setup({})
+      require("vscode").load()
+    end,
+  },
 })


### PR DESCRIPTION
## Summary
- add Mofiqul/vscode.nvim colorscheme
- document use of VS Code colorscheme

## Testing
- `nvim --headless -c "q"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687812376868832cbec88b03e5bfffae