### PR TITLE
Add gitsigns plugin

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -21,3 +21,6 @@ Launch it with `<leader>f` (space + f).
 ## VS Code Theme
 The colorscheme uses **Mofiqul/vscode.nvim** to mimic VS Code's look.
 
+## Git Integration
+The setup includes **gitsigns.nvim** for inline git information similar to GitLens.
+Signs show added, modified, and deleted lines and you can toggle blame with `:Gitsigns toggle_current_line_blame`.

--- a/init.lua
+++ b/init.lua
@@ -77,4 +77,11 @@ require("lazy").setup({
       require("vscode").load()
     end,
   },
+  {
+    "lewis6991/gitsigns.nvim",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    config = function()
+      require("gitsigns").setup()
+    end,
+  },
 })


### PR DESCRIPTION
## Summary
- include `gitsigns.nvim` for git integration similar to GitLens
- document the new git features

## Testing
- `nvim --headless +'quit'` *(fails: nvim not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68785ffba4dc832ca8e46d0b7d248027