### PR TITLE
Set vertical bar cursor style

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,6 +12,10 @@ vim.opt.termguicolors = true
 vim.opt.mouse = "a"
 vim.opt.clipboard = "unnamedplus"
 
+-- Cursor Style
+-- Use a thin vertical bar to mimic VS Code's cursor
+vim.opt.guicursor = "a:ver25"
+
 -- Leader Key
 vim.g.mapleader = " "
 


### PR DESCRIPTION
## Summary
- customize `guicursor` to use a thin vertical bar like VS Code

## Testing
- `nvim --headless -u init.lua +q` *(fails: `nvim` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687862933e00832cb8df1a4cb70762d5