### PR TITLE
Add <leader>p mapping for fuzzy finder

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,7 +16,7 @@ Toggle it with `<leader>e` (space + e). Files are displayed with icons thanks to
 ## Fuzzy Finder
 The setup includes **telescope.nvim** with the **telescope-fzf-native** extension
 for faster fuzzy searching.
-Launch it with `<leader>f` (space + f).
+Launch it with `<leader>f` (space + f) or `<leader>p` (space + p).
 
 ## VS Code Theme
 The colorscheme uses **Mofiqul/vscode.nvim** to mimic VS Code's look.

--- a/init.lua
+++ b/init.lua
@@ -70,6 +70,12 @@ require("lazy").setup({
         "<cmd>Telescope find_files<CR>",
         { silent = true, desc = "Fuzzy find files" }
       )
+      vim.keymap.set(
+        "n",
+        "<leader>p",
+        "<cmd>Telescope find_files<CR>",
+        { silent = true, desc = "Fuzzy find files" }
+      )
     end,
   },
   {


### PR DESCRIPTION
## Summary
- map `<leader>p` to launch Telescope's find_files
- document the new shortcut in README

## Testing
- `nvim --headless +quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687868d31864832cbfeecb7ac7afc1d6