### PR TITLE
Update key mappings for escape and file explorer

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,7 +11,8 @@
 
 ## File Explorer
 The configuration uses **nvim-tree.lua** for browsing files.
-Toggle it with `<leader>e` (space + e). Files are displayed with icons thanks to **nvim-web-devicons**.
+Toggle it with `<leader>[` (space + \[). Files are displayed with icons thanks to **nvim-web-devicons**.
+You can also press `<leader>e` in insert mode to escape back to normal mode.
 
 ## Fuzzy Finder
 The setup includes **telescope.nvim** with the **telescope-fzf-native** extension

--- a/init.lua
+++ b/init.lua
@@ -22,6 +22,9 @@ vim.g.mapleader = " "
 -- Make space do nothing in normal and visual modes
 vim.keymap.set({ "n", "v" }, "<Space>", "<Nop>", { silent = true })
 
+-- Map <leader>e to act as Escape
+vim.keymap.set("i", "<leader>e", "<Esc>", { desc = "Escape insert mode" })
+
 -- Exit Commands
 vim.keymap.set('n', '<leader>q', ':qa<CR>', { desc = 'Quit all' })
 
@@ -44,7 +47,7 @@ require("lazy").setup({
       require("nvim-tree").setup()
       vim.keymap.set(
         "n",
-        "<leader>e",
+        "<leader>[",
         "<cmd>NvimTreeToggle<CR>",
         { silent = true, desc = "Toggle file explorer" }
       )


### PR DESCRIPTION
## Summary
- allow `<leader>e` to exit insert mode just like `<Esc>`
- move file explorer toggle to `<leader>[`
- document the new mappings in **ReadMe.md**

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68787435fab0832cb44d77e396de22a0