### PR TITLE
Fix telescope mode

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,7 +16,7 @@ Toggle it with `<leader>e` (space + e). Files are displayed with icons thanks to
 ## Fuzzy Finder
 The setup includes **telescope.nvim** with the **telescope-fzf-native** extension
 for faster fuzzy searching.
-Launch grep with `<leader>f` (space + f) or fuzzy file search with `<leader>p` (space + p).
+Launch grep with `<leader>f` (space + f). Fuzzy file search is available with `<leader>p` (space + p); it opens in normal mode so pressing `<Esc>` once closes the picker.
 
 ## VS Code Theme
 The colorscheme uses **Mofiqul/vscode.nvim** to mimic VS Code's look.

--- a/init.lua
+++ b/init.lua
@@ -82,7 +82,9 @@ require("lazy").setup({
       vim.keymap.set(
         "n",
         "<leader>p",
-        "<cmd>Telescope find_files<CR>",
+        function()
+          require("telescope.builtin").find_files({ initial_mode = "normal" })
+        end,
         { silent = true, desc = "Fuzzy find files" }
       )
     end,


### PR DESCRIPTION
## Summary
- open Telescope `find_files` in normal mode
- note new fuzzy finder behaviour in ReadMe

## Testing
- `nvim --headless -u NONE -c 'luafile init.lua' -c 'qa'` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687873f3da58832c93f86d996394f0cd