### PR TITLE
Add GitHub Copilot support

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -24,3 +24,8 @@ The colorscheme uses **Mofiqul/vscode.nvim** to mimic VS Code's look.
 ## Git Integration
 The setup includes **gitsigns.nvim** for inline git information similar to GitLens.
 Signs show added, modified, and deleted lines and you can toggle blame with `:Gitsigns toggle_current_line_blame`.
+
+## AI Assistance
+This setup includes **github/copilot.vim** to bring GitHub Copilot suggestions
+into Neovim. After installation, run `:Copilot setup` to sign in. Accept a
+suggestion in insert mode by pressing `<Tab>`, just like in VS Code.

--- a/init.lua
+++ b/init.lua
@@ -96,7 +96,7 @@ require("lazy").setup({
       require("vscode").load()
     end,
   },
-{
+  {
     "lewis6991/gitsigns.nvim",
     config = function()
         require("gitsigns").setup({
@@ -107,5 +107,18 @@ require("lazy").setup({
         },
         })
     end
-}
+  },
+  {
+    "github/copilot.vim",
+    config = function()
+      -- Use <Tab> to accept Copilot suggestions like VS Code
+      vim.g.copilot_no_tab_map = true
+      vim.api.nvim_set_keymap(
+        "i",
+        "<Tab>",
+        'copilot#Accept("\<CR>")',
+        { silent = true, expr = true, script = true, replace_keycodes = false }
+      )
+    end,
+  }
 })


### PR DESCRIPTION
## Summary
- integrate `github/copilot.vim` for AI completion
- document Copilot usage in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687874eb24e4832c8eb9b8c7da7c791c