### PR TITLE
Add theme toggle shortcut

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,6 +20,7 @@ Launch grep with `<leader>f` (space + f) or fuzzy file search with `<leader>p` (
 
 ## VS Code Theme
 The colorscheme uses **Mofiqul/vscode.nvim** to mimic VS Code's look.
+Toggle between light and dark modes with `<leader>t` (space + t).
 
 ## Git Integration
 The setup includes **gitsigns.nvim** for inline git information similar to GitLens.

--- a/init.lua
+++ b/init.lua
@@ -94,6 +94,19 @@ require("lazy").setup({
         disable_nvimtree_bg = false,
       })
       require("vscode").load()
+      vim.keymap.set(
+        "n",
+        "<leader>t",
+        function()
+          if vim.o.background == "dark" then
+            vim.o.background = "light"
+          else
+            vim.o.background = "dark"
+          end
+          require("vscode").load()
+        end,
+        { desc = "Toggle VS Code theme" }
+      )
     end,
   },
 {


### PR DESCRIPTION
## Summary
- add a `<leader>t` mapping to switch between VS Code light and dark themes
- document the new shortcut in the README

## Testing
- `nvim --headless +'q'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68787526e7f8832c9d91f7f4bf441884