### PR TITLE
Enable single-click open in nvim-tree

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,6 +12,7 @@
 ## File Explorer
 The configuration uses **nvim-tree.lua** for browsing files.
 Toggle it with `<leader>e` (space + e). Files are displayed with icons thanks to **nvim-web-devicons**.
+Files can be opened with a single mouse click inside the tree just like in VS Code.
 
 ## Fuzzy Finder
 The setup includes **telescope.nvim** with the **telescope-fzf-native** extension

--- a/init.lua
+++ b/init.lua
@@ -41,7 +41,15 @@ require("lazy").setup({
     "nvim-tree/nvim-tree.lua",
     dependencies = { "nvim-tree/nvim-web-devicons" },
     config = function()
-      require("nvim-tree").setup()
+      require("nvim-tree").setup({
+        view = {
+          mappings = {
+            list = {
+              { key = "<LeftRelease>", action = "edit", mode = "n" },
+            },
+          },
+        },
+      })
       vim.keymap.set(
         "n",
         "<leader>e",


### PR DESCRIPTION
## Summary
- make nvim-tree open files with a single mouse click
- document mouse click behavior in README

## Testing
- `nvim` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68787316d16c832cb2e9b40dd6ce7fb9