### PR TITLE
Add nvim-lspconfig for LSP support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -105,6 +105,14 @@ require("lazy").setup({
       require("vscode").load()
     end,
   },
+  {
+    "neovim/nvim-lspconfig",
+    config = function()
+      local lspconfig = require("lspconfig")
+      lspconfig.lua_ls.setup({})
+      lspconfig.pyright.setup({})
+    end,
+  },
 {
     "lewis6991/gitsigns.nvim",
     config = function()


### PR DESCRIPTION
## Summary
- enable language server support with `nvim-lspconfig`

## Testing
- `luac -p init.lua` *(fails: command not found)*
- `nvim --headless +quit` *(fails: command not found)*
- `sudo apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6878e21f078c832cb8a4c4a8f560b87a