### PR TITLE
Add bufferline for buffer management

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -28,3 +28,6 @@ Signs show added, modified, and deleted lines and you can toggle blame with `:Gi
 ## Syntax Highlighting
 **nvim-treesitter** provides better code highlighting and indentation.
 Parsers update automatically via `:TSUpdate`
+
+## Buffer Tabs
+Use **bufferline.nvim** to view open buffers in a tab line. Navigate with `<S-h>` and `<S-l>` and close the current buffer with `<leader>c`.

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -6,6 +6,7 @@ vim.opt.rtp:prepend(lazypath)
 local plugins = {
   require("plugins.tree"),
   require("plugins.telescope"),
+  require("plugins.bufferline"),
   require("plugins.vscode"),
   require("plugins.treesitter"),
   require("plugins.gitsigns"),

--- a/lua/plugins/bufferline.lua
+++ b/lua/plugins/bufferline.lua
@@ -1,0 +1,11 @@
+return {
+  "akinsho/bufferline.nvim",
+  version = "*",
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  config = function()
+    require("bufferline").setup{}
+    vim.keymap.set("n", "<S-h>", "<cmd>BufferLineCyclePrev<CR>", { desc = "Previous buffer" })
+    vim.keymap.set("n", "<S-l>", "<cmd>BufferLineCycleNext<CR>", { desc = "Next buffer" })
+    vim.keymap.set("n", "<leader>c", "<cmd>bdelete<CR>", { desc = "Close buffer" })
+  end,
+}


### PR DESCRIPTION
## Summary
- use bufferline.nvim for tab-like buffer switching
- document bufferline keymaps

## Testing
- `nvim --headless "+quit"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878fe43ca7c832c96e6ec5ffe7bb226