### PR TITLE
Ensure buffers start in normal mode

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -31,3 +31,6 @@ Parsers update automatically via `:TSUpdate`
 
 ## Buffer Tabs
 Use **bufferline.nvim** to view open buffers in a tab line. Navigate with `<S-h>` and `<S-l>` and close the current buffer with `<leader>c`.
+
+## Normal Mode on Buffer Open
+Buffers always switch to Normal mode when opened via the tree, Telescope, or bufferline.

--- a/init.lua
+++ b/init.lua
@@ -2,4 +2,5 @@
 
 require("config.options")
 require("config.keymaps")
+require("config.autocmds")
 require("plugins")

--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -1,0 +1,7 @@
+-- Autocommands
+-- Ensure entering any buffer starts in Normal mode
+vim.api.nvim_create_autocmd("BufEnter", {
+  pattern = "*",
+  command = "stopinsert",
+})
+


### PR DESCRIPTION
## Summary
- add autocommand to exit insert mode whenever entering a buffer
- document new behavior

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687907984dc0832c813f5763ca1a3099