### PR TITLE
Add oil.nvim plugin

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,6 +13,7 @@
 The configuration uses **nvim-tree.lua** for browsing files.
 Toggle it with `<leader>e` (space + e). Files are displayed with icons thanks to **nvim-web-devicons**.
 Files and folders open with a single mouse click for a more VS Code like feel.
+You can also open the current directory in a buffer using **oil.nvim** with `<leader>o`.
 
 ## Fuzzy Finder
 The setup includes **telescope.nvim** with the **telescope-fzf-native** extension

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -5,6 +5,7 @@ vim.opt.rtp:prepend(lazypath)
 -- Load individual plugin specs
 local plugins = {
   require("plugins.tree"),
+  require("plugins.oil"),
   require("plugins.telescope"),
   require("plugins.bufferline"),
   require("plugins.vscode"),

--- a/lua/plugins/oil.lua
+++ b/lua/plugins/oil.lua
@@ -1,0 +1,13 @@
+return {
+  "stevearc/oil.nvim",
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  config = function()
+    require("oil").setup()
+    vim.keymap.set(
+      "n",
+      "<leader>o",
+      require("oil").open,
+      { desc = "Open Oil" }
+    )
+  end,
+}


### PR DESCRIPTION
## Summary
- add `oil.nvim` plugin to the lazy plugin list
- provide a keymap for Oil in its own plugin config
- document the Oil keybinding in the README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687945a07058832ca9a923438254531a