### PR TITLE
feat: add which-key for leader hints

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -10,6 +10,7 @@ local plugins = {
   require("plugins.vscode"),
   require("plugins.treesitter"),
   require("plugins.gitsigns"),
+  require("plugins.whichkey"),
 }
 
 -- Plugin Setup

--- a/lua/plugins/whichkey.lua
+++ b/lua/plugins/whichkey.lua
@@ -1,0 +1,11 @@
+return {
+  "folke/which-key.nvim",
+  lazy = false,
+  config = function()
+    local wk = require("which-key")
+    wk.setup({
+      triggers = { "<leader>" },
+      triggers_nowait = { "<leader>" },
+    })
+  end,
+}

--- a/lua/plugins/whichkey.lua
+++ b/lua/plugins/whichkey.lua
@@ -2,6 +2,7 @@ return {
   "folke/which-key.nvim",
   lazy = false,
   config = function()
+    vim.o.timeout = false
     local wk = require("which-key")
     wk.setup({
       triggers = { "<leader>" },


### PR DESCRIPTION
## Summary
- add which-key plugin
- show which-key window instantly when pressing `<leader>`

## Testing
- `nvim --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y neovim` *(fails: no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68a78174ee34832cbf0a1ebd29992984